### PR TITLE
Venom fixes

### DIFF
--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -37,6 +37,9 @@ class OrderedSet(Generic[_T]):
     def __iter__(self):
         return iter(self._data)
 
+    def __reversed__(self):
+        return reversed(self._data)
+
     def __contains__(self, item):
         return self._data.__contains__(item)
 

--- a/vyper/venom/basicblock.py
+++ b/vyper/venom/basicblock.py
@@ -342,7 +342,7 @@ def _ir_operand_from_value(val: Any) -> IROperand:
     if isinstance(val, IROperand):
         return val
 
-    assert isinstance(val, int), val
+    assert isinstance(val, int), (type(val), val)
     return IRLiteral(val)
 
 

--- a/vyper/venom/basicblock.py
+++ b/vyper/venom/basicblock.py
@@ -284,7 +284,7 @@ class IRInstruction:
         """
         return [self.output] if self.output else []
 
-    def can_reorder(self, other: IRInstruction):
+    def can_reorder(self, other: "IRInstruction") -> bool:
         return (self.parent, self.fence_id) == (other.parent, other.fence_id)
 
     def replace_operands(self, replacements: dict) -> None:

--- a/vyper/venom/basicblock.py
+++ b/vyper/venom/basicblock.py
@@ -284,6 +284,9 @@ class IRInstruction:
         """
         return [self.output] if self.output else []
 
+    def can_reorder(self, other: IRInstruction):
+        return (self.parent, self.fence_id) == (other.parent, other.fence_id)
+
     def replace_operands(self, replacements: dict) -> None:
         """
         Update operands with replacements.

--- a/vyper/venom/ir_node_to_venom.py
+++ b/vyper/venom/ir_node_to_venom.py
@@ -169,7 +169,7 @@ def _handle_self_call(ctx: IRFunction, ir: IRnode, symbols: SymbolTable) -> Opti
 
     bb = ctx.get_basic_block()
     if len(goto_ir.args) > 2:
-        ret_args.append(return_buf.value)  # type: ignore
+        ret_args.append(return_buf)  # type: ignore
 
     bb.append_invoke_instruction(ret_args, returns=False)  # type: ignore
 

--- a/vyper/venom/ir_node_to_venom.py
+++ b/vyper/venom/ir_node_to_venom.py
@@ -539,7 +539,7 @@ def _convert_ir_bb(ctx, ir, symbols):
             ctx.get_basic_block().append_instruction("alloca", *ir.passthrough_metadata["alloca"])
         return symbols[ir.value]
     elif ir.is_literal:
-        return IRLiteral(ir.value)
+        return ctx.get_basic_block().append_instruction("store", IRLiteral(ir.value))
     else:
         raise Exception(f"Unknown IR node: {ir}")
 

--- a/vyper/venom/passes/dft.py
+++ b/vyper/venom/passes/dft.py
@@ -1,6 +1,6 @@
 from vyper.utils import OrderedSet
 from vyper.venom.analysis import DFG
-from vyper.venom.basicblock import IRBasicBlock, IRInstruction
+from vyper.venom.basicblock import IRBasicBlock, IRInstruction, IRVariable
 from vyper.venom.function import IRFunction
 from vyper.venom.passes.base_pass import IRPass
 
@@ -8,6 +8,7 @@ from vyper.venom.passes.base_pass import IRPass
 class DFTPass(IRPass):
     def _process_instruction_r(self, bb: IRBasicBlock, inst: IRInstruction):
         for op in inst.get_outputs():
+            assert isinstance(op, IRVariable)  # help mypy
             for uses_this in self.dfg.get_uses(op):
                 if not uses_this.can_reorder(inst):
                     continue

--- a/vyper/venom/passes/dft.py
+++ b/vyper/venom/passes/dft.py
@@ -9,8 +9,7 @@ class DFTPass(IRPass):
     def _process_instruction_r(self, bb: IRBasicBlock, inst: IRInstruction):
         for op in inst.get_outputs():
             for uses_this in self.dfg.get_uses(op):
-                if uses_this.parent != inst.parent or uses_this.fence_id != inst.fence_id:
-                    # don't reorder across basic block or fence boundaries
+                if not uses_this.can_reorder(inst):
                     continue
                 self._process_instruction_r(bb, uses_this)
 
@@ -28,8 +27,7 @@ class DFTPass(IRPass):
         for op in inst.get_inputs():
             target = self.dfg.get_producing_instruction(op)
             assert target is not None, f"no producing instruction for {op}"
-            if target.parent != inst.parent or target.fence_id != inst.fence_id:
-                # don't reorder across basic block or fence boundaries
+            if not target.can_reorder(inst):
                 continue
             self._process_instruction_r(bb, target)
 

--- a/vyper/venom/passes/dft.py
+++ b/vyper/venom/passes/dft.py
@@ -7,8 +7,16 @@ from vyper.venom.passes.base_pass import IRPass
 
 class DFTPass(IRPass):
     def _process_instruction_r(self, bb: IRBasicBlock, inst: IRInstruction):
+        for op in inst.get_outputs():
+            for uses_this in self.dfg.get_uses(op):
+                if uses_this.parent != inst.parent or uses_this.fence_id != inst.fence_id:
+                    # don't reorder across basic block or fence boundaries
+                    continue
+                self._process_instruction_r(bb, uses_this)
+
         if inst in self.visited_instructions:
             return
+
         self.visited_instructions.add(inst)
 
         if inst.opcode == "phi":
@@ -17,10 +25,10 @@ class DFTPass(IRPass):
             bb.instructions.append(inst)
             return
 
-        for op in inst.liveness:
+        for op in inst.get_inputs():
             target = self.dfg.get_producing_instruction(op)
             assert target is not None, f"no producing instruction for {op}"
-            if target is None or target.parent != inst.parent or target.fence_id != inst.fence_id:
+            if target.parent != inst.parent or target.fence_id != inst.fence_id:
                 # don't reorder across basic block or fence boundaries
                 continue
             self._process_instruction_r(bb, target)

--- a/vyper/venom/venom_to_assembly.py
+++ b/vyper/venom/venom_to_assembly.py
@@ -532,7 +532,7 @@ class VenomCompiler:
             elif len(next_liveness) > 0 and stack.height > 0:
                 next_top = next(reversed(next_liveness))
                 if stack.peek(0) != next_top:
-                    self.swap_op(assembly, stack, next(reversed(next_liveness)))
+                    self.swap_op(assembly, stack, next_top)
 
         return apply_line_numbers(inst, assembly)
 

--- a/vyper/venom/venom_to_assembly.py
+++ b/vyper/venom/venom_to_assembly.py
@@ -527,7 +527,7 @@ class VenomCompiler:
 
         # Step 6: Emit instructions output operands (if any)
         if inst.output is not None:
-            if "call" in inst.opcode and inst.output not in next_liveness:
+            if inst.output not in next_liveness:
                 self.pop(assembly, stack)
 
         return apply_line_numbers(inst, assembly)

--- a/vyper/venom/venom_to_assembly.py
+++ b/vyper/venom/venom_to_assembly.py
@@ -529,6 +529,10 @@ class VenomCompiler:
         if inst.output is not None:
             if inst.output not in next_liveness:
                 self.pop(assembly, stack)
+            elif len(next_liveness) > 0 and stack.height > 0:
+                next_top = next(reversed(next_liveness))
+                if stack.peek(0) != next_top:
+                    self.swap_op(assembly, stack, next(reversed(next_liveness)))
 
         return apply_line_numbers(inst, assembly)
 


### PR DESCRIPTION
### What I did
- fix dft pass (maybe)
- issue variables for literals so they can be reordered via dftpass
- add a heuristic to swap the top of the stack if it's not the next thing to be consumed

### How I did it

### How to verify it
compile this contract
```vyper
#pragma experimental-codegen
@external
def foo(x: uint256, y: uint256) -> uint256:
    return x * y
```
output should include `DUP2 DUP2 MUL SWAP1 DUP3 DUP3 DIV EQ SWAP2 ISZERO SWAP1 SWAP2 OR ISZERO` which shows that the output of MUL is getting swapped out after it is produced

also, a bunch of things like `CALLDATASIZE PUSH1 0x44 SWAP1 LT` get reordered so the swaps are removed.

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
