### PR TITLE
some dft improvements

### DIFF
--- a/vyper/venom/passes/dft.py
+++ b/vyper/venom/passes/dft.py
@@ -70,13 +70,15 @@ class DFTPass(IRPass):
         if inst.is_pseudo:
             return
 
-        children = sorted(
-            self.ida[inst],
-            key=lambda x: (
-                -self.inst_offspring_count[x] + (x.opcode == "iszero") * 10,
-                inst.operands.index(x.output) if x.output in inst.operands else 0,
-            ),
-        )
+        def cost(x):
+            s = 0
+            for op in enumerate(inst.operands):
+                if x.output == op:
+                    s = i
+                    break
+            return s, -self.inst_offspring_count[x]
+
+        children = sorted(self.ida[inst], key=cost)
 
         for dep_inst in children:
             if inst.parent != dep_inst.parent:

--- a/vyper/venom/passes/dft.py
+++ b/vyper/venom/passes/dft.py
@@ -79,14 +79,14 @@ class DFTPass(IRPass):
                     break
             return s, -len(self.inst_offspring[x])
 
-        for dep_inst in self.ida[inst]:
-            self._process_instruction_r(instructions, dep_inst)
-
         barriers = list(self.barriers[inst])
         #barriers.sort(key=cost)
 
         for barrier_inst in barriers:
             self._process_instruction_r(instructions, barrier_inst)
+
+        for dep_inst in self.ida[inst]:
+            self._process_instruction_r(instructions, dep_inst)
 
         instructions.append(inst)
 

--- a/vyper/venom/venom_to_assembly.py
+++ b/vyper/venom/venom_to_assembly.py
@@ -25,7 +25,7 @@ from vyper.venom.context import IRContext
 from vyper.venom.passes.normalization import NormalizationPass
 from vyper.venom.stack_model import StackModel
 
-DEBUG_SHOW_COST = False
+DEBUG_SHOW_COST = True
 if DEBUG_SHOW_COST:
     import sys
 


### PR DESCRIPTION
### What I did
- refactor dependency graph - split operand dependencies and barrier "dependencies"
- remove children sorting
- visit barriers before operand dependencies

this improves codesize across several contracts, i checked:
- branch_storm.vy
- examples/tokens/ERC20.vy
- examples/voting/ballot.vy
- CurveStableSwapNG-0.4.1.vy

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
